### PR TITLE
Feature/allow unconfigured run

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ Documentation:
   Enabled: False
 HashSyntax:
   Enabled: False
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,6 @@
-site :opscode
+source 'https://supermarket.chef.io'
 
 group :integration do
-  cookbook 'minitest-handler'
   cookbook 'hadoop'
   cookbook 'java'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,20 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf', '~> 3.0'
-gem 'foodcritic', '~> 3.0'
+gem 'foodcritic', '~> 4.0'
 
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 
+if RUBY_VERSION.to_f < 2.0
+  gem 'chef', '< 12.0'
+  gem 'varia_model', '< 0.5.0'
+else
+  gem 'chef', '< 12.5' # Testing
+end
+
+gem 'ridley', '~> 4.2.0'
+gem 'faraday', '< 0.9.2'
 gem 'rubocop'
 gem 'rubocop-checkstyle_formatter', require: false
 gem 'rainbow', '<= 1.99.1'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,3 +4,4 @@ default['krb5_utils']['keytabs_dir'] = '/etc/security/keytabs'
 default['krb5_utils']['krb5_service_keytabs'] = {}
 default['krb5_utils']['krb5_user_keytabs'] = {}
 default['krb5_utils']['add_http_principal'] = true
+default['krb5_utils']['destroy_before_kinit'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,5 +25,5 @@ package 'kstart'
 
 # Generate any defined keytabs
 unless node['krb5_utils']['krb5_service_keytabs'].empty? && node['krb5_utils']['krb5_user_keytabs'].empty?
-  include_recipe 'krb5::generate_keytabs'
+  include_recipe 'krb5_utils::generate_keytabs'
 end

--- a/recipes/generate_keytabs.rb
+++ b/recipes/generate_keytabs.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'krb5::kinit_as_admin'
+include_recipe 'krb5_utils::kinit_as_admin'
 
 keytab_dir = node['krb5_utils']['keytabs_dir']
 

--- a/recipes/generate_keytabs.rb
+++ b/recipes/generate_keytabs.rb
@@ -1,0 +1,77 @@
+#
+# Cookbook Name:: krb5_utils
+# Recipe:: generate_keytabs
+#
+# Copyright © 2016 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'krb5::kinit_as_admin'
+
+keytab_dir = node['krb5_utils']['keytabs_dir']
+
+directory keytab_dir do
+  owner 'root'
+  group 'root'
+  mode '0755'
+  action :create
+end
+
+# Generate execute blocks
+%w(krb5_service_keytabs krb5_user_keytabs).each do |kt|
+  node['krb5_utils'][kt].each do |name, opts|
+    case kt
+    when 'krb5_service_keytabs'
+      if node['krb5_utils']['add_http_principal']
+        http_principal = "HTTP/#{node['fqdn']}@#{node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase}"
+      else
+        http_principal = ''
+      end
+      principal = "#{name}/#{node['fqdn']}@#{node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase}"
+      keytab_file = "#{name}.service.keytab"
+      randkey = '-randkey'
+    when 'krb5_user_keytabs'
+      http_principal = ''
+      principal = "#{name}@#{node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase}"
+      keytab_file = "#{name}.keytab"
+      randkey = '-norandkey'
+    end
+
+    execute "krb5-addprinc-#{principal}" do
+      command "kadmin -w #{node['krb5_utils']['admin_password']} -q 'addprinc #{randkey} #{principal}'"
+      action :run
+      not_if "kadmin -w #{node['krb5_utils']['admin_password']} -q 'list_principals' | grep -v Auth | grep '^#{principal}'"
+    end
+
+    execute "krb5-check-#{principal}" do
+      command "kadmin -w #{node['krb5_utils']['admin_password']} -q 'list_principals' | grep -v Auth | grep '^#{principal}'"
+      action :run
+      not_if "test -e #{keytab_dir}/#{keytab_file}"
+    end
+
+    execute "krb5-generate-keytab-#{keytab_file}" do
+      command "kadmin -w #{node['krb5_utils']['admin_password']} -q 'xst -kt #{keytab_dir}/#{keytab_file} #{principal} #{http_principal}'"
+      action :run
+      not_if "test -e #{keytab_dir}/#{keytab_file}"
+    end
+
+    file "#{keytab_dir}/#{keytab_file}" do
+      owner opts.owner
+      group opts.group
+      mode opts.mode
+      action :create
+      only_if "test -e #{keytab_dir}/#{keytab_file}"
+    end
+  end
+end

--- a/recipes/generate_keytabs.rb
+++ b/recipes/generate_keytabs.rb
@@ -33,11 +33,11 @@ end
   node['krb5_utils'][kt].each do |name, opts|
     case kt
     when 'krb5_service_keytabs'
-      if node['krb5_utils']['add_http_principal']
-        http_principal = "HTTP/#{node['fqdn']}@#{node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase}"
-      else
-        http_principal = ''
-      end
+      http_principal = if node['krb5_utils']['add_http_principal']
+                         "HTTP/#{node['fqdn']}@#{node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase}"
+                       else
+                         ''
+                       end
       principal = "#{name}/#{node['fqdn']}@#{node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase}"
       keytab_file = "#{name}.service.keytab"
       randkey = '-randkey'

--- a/recipes/kinit_as_admin.rb
+++ b/recipes/kinit_as_admin.rb
@@ -1,8 +1,8 @@
 #
 # Cookbook Name:: krb5_utils
-# Recipe:: default
+# Recipe:: kinit_as_admin
 #
-# Copyright © 2013-2016 Cask Data, Inc.
+# Copyright © 2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@
 
 include_recipe 'krb5::default'
 
-# Install 'kstart' for k5start command
-include_recipe 'yum-epel::default' if node['platform_family'] == 'rhel'
-package 'kstart'
+execute 'kdestroy' do
+  command 'kdestroy'
+  action :run
+end
 
-# Generate any defined keytabs
-unless node['krb5_utils']['krb5_service_keytabs'].empty? && node['krb5_utils']['krb5_user_keytabs'].empty?
-  include_recipe 'krb5::generate_keytabs'
+execute 'kinit-as-admin-user' do
+  command "echo #{node['krb5_utils']['admin_password']} | kinit #{node['krb5_utils']['admin_principal']}"
+  action :run
 end

--- a/recipes/kinit_as_admin.rb
+++ b/recipes/kinit_as_admin.rb
@@ -22,6 +22,7 @@ include_recipe 'krb5::default'
 execute 'kdestroy' do
   command 'kdestroy'
   action :run
+  only_if { node['krb5_utils']['destroy_before_kinit'].to_s == 'true' }
 end
 
 execute 'kinit-as-admin-user' do


### PR DESCRIPTION
This allows the Coopr [kerberos-client service](https://github.com/caskdata/coopr-templates/blob/develop/services/kerberos-client.json) to be run without any configuration to simply install the kerberos client libraries.  Previously, it would attempt to kadmin and fail.
- [x] splits the keytab generation logic into its own recipe and conditionally includes it only if any keytabs are defined
- [x] rubocop and testing updates

```
Finished in 6.09 seconds (files took 3.16 seconds to load)
16 examples, 0 failures
```