### PR TITLE
Set ntp.sync_clock to true for users of ntp cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,3 +5,5 @@ default['krb5_utils']['krb5_service_keytabs'] = {}
 default['krb5_utils']['krb5_user_keytabs'] = {}
 default['krb5_utils']['add_http_principal'] = true
 default['krb5_utils']['destroy_before_kinit'] = true
+# Force a clock sync, so we don't fail to query/create principals/keytabs
+default['ntp']['sync_clock'] = true


### PR DESCRIPTION
This forces a clock sync on every Chef run, if the user has the `ntp` cookbook installed. This may not necessarily be what someone wants, but this will ensure that the clock is synchronized prior to performing Kerberos operations, which are clock skew sensitive.