### PR TITLE
Use grep to parse kadmin get_principal output

### DIFF
--- a/recipes/generate_keytabs.rb
+++ b/recipes/generate_keytabs.rb
@@ -51,11 +51,11 @@ end
     execute "krb5-addprinc-#{principal}" do
       command "kadmin -w #{node['krb5_utils']['admin_password']} -q 'addprinc #{randkey} #{principal}'"
       action :run
-      not_if "kadmin -w #{node['krb5_utils']['admin_password']} -q 'get_principal #{principal}'"
+      not_if "kadmin -w #{node['krb5_utils']['admin_password']} -q 'get_principal #{principal}' | grep #{principal}"
     end
 
     execute "krb5-check-#{principal}" do
-      command "kadmin -w #{node['krb5_utils']['admin_password']} -q 'get_principal #{principal}'"
+      command "kadmin -w #{node['krb5_utils']['admin_password']} -q 'get_principal #{principal}' | grep #{principal}"
       action :run
       not_if "test -e #{keytab_dir}/#{keytab_file}"
     end


### PR DESCRIPTION
All `kadmin` queries return 0 unless there is an error performing the query. This doesn't work well when used as a guard on Chef resources.

Before:
```
$ kadmin -q 'get_principal admin/admin' >/dev/null; echo $?
0
$ kadmin -q 'get_principal fake_user' >/dev/null; echo $?
0
```

After:
```
$ kadmin -q 'get_principal admin/admin' | grep admin/admin >/dev/null; echo $?
0
$ kadmin -w password -q 'get_principal fake_user' | grep fake_user >/dev/null; echo $?
get_principal: Principal does not exist while retrieving "fake_user@EXAMPLE.COM".
1
```