### PR TITLE
Version bump to 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 krb_utils CHANGELOG
 ===================
 
+v0.2.2 (Sep 16, 2016)
+---------------------
+- Set ntp.sync_clock to true for users of ntp cookbook ( Issue: #14 )
+- Use grep to parse kadmin get_principal output ( Issue: #15 )
+
 v0.2.1 (Sep 13, 2016)
 ---------------------
 - Create LICENSE.txt via GitHub ( Issue: #8 )

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,7 @@
   "recipes": {
 
   },
-  "version": "0.2.1",
-  "source_url": "",
-  "issues_url": ""
+  "version": "0.2.2",
+  "source_url": "https://github.com/caskdata/krb5_utils_cookbook",
+  "issues_url": "https://issues.cask.co/browse/COOK/component/10602"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'ops@cask.co'
 license          'Apache License, Version 2.0'
 description      'Set of utility resources which can be used to setup Kerberos'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.2.2'
 
 depends 'krb5', '>= 1.0.4'
 depends 'yum-epel'
@@ -12,3 +12,6 @@ depends 'yum-epel'
 %w(amazon centos debian redhat scientific ubuntu).each do |os|
   supports os
 end
+
+source_url 'https://github.com/caskdata/krb5_utils_cookbook' if respond_to?(:source_url)
+issues_url 'https://issues.cask.co/browse/COOK/component/10602' if respond_to?(:issues_url)


### PR DESCRIPTION
Includes:

- Set ntp.sync_clock to true for users of ntp cookbook ( Issue: #14 )
- Use grep to parse kadmin get_principal output ( Issue: #15 )